### PR TITLE
Update Unity packages for 2021.3

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,9 @@
 {
   "dependencies": {
-    "com.unity.ads": "2.0.8",
-    "com.unity.analytics": "3.2.2",
-    "com.unity.collab-proxy": "1.2.15",
-    "com.unity.package-manager-ui": "2.0.7",
-    "com.unity.purchasing": "2.0.3",
-    "com.unity.textmeshpro": "1.4.1",
+    "com.unity.ads": "4.4.2",
+    "com.unity.analytics": "3.8.1",
+    "com.unity.purchasing": "4.1.2",
+    "com.unity.textmeshpro": "3.0.9",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",


### PR DESCRIPTION
## Summary
- update Ads, Analytics, Purchasing, TextMeshPro packages
- remove deprecated Collab Proxy and Package Manager UI packages

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6851818f87e8832cbfba517b8c2513d8